### PR TITLE
Support Guzzle 6 as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.6",
         "illuminate/console": ">=5.1",
         "illuminate/support": ">=5.1",
-        "guzzlehttp/guzzle": "^5.3"
+        "guzzlehttp/guzzle": "^5.3|^6.2"
     },
     "require-dev": {
         "orchestra/testbench": "^3.3",


### PR DESCRIPTION
After very rudimentary testing, this seems to be all that's necessary to accommodate Guzzle 6 and Laravel 5.4 and PHP 7.1

Fixes #2 