### PR TITLE
Check if Cloudflare header "CF-Connecting-IP" exists.

### DIFF
--- a/src/Http/Middleware/Request.php
+++ b/src/Http/Middleware/Request.php
@@ -23,7 +23,8 @@ class Request
     {
 
         // check if the source is trusted
-        $requestIp = $request->server('HTTP_CF_CONNECTING_IP') ?? $request->server('REMOTE_ADDR');
+        $requestIp = $request->server('HTTP_CF_CONNECTING_IP') ? $request->server('HTTP_CF_CONNECTING_IP') : $request->server('REMOTE_ADDR');
+        
         if (! in_array($requestIp, [$_SERVER['SERVER_ADDR'], '127.0.0.1', '::1'])) {
             throw new AuthorizationException('This action is unauthorized.');
         }

--- a/src/Http/Middleware/Request.php
+++ b/src/Http/Middleware/Request.php
@@ -24,7 +24,7 @@ class Request
 
         // check if the source is trusted
         $requestIp = $request->server('HTTP_CF_CONNECTING_IP') ?? $request->server('REMOTE_ADDR');
-        if (!in_array($requestIp, [$_SERVER['SERVER_ADDR'], '127.0.0.1', '::1'])) {
+        if (! in_array($requestIp, [$_SERVER['SERVER_ADDR'], '127.0.0.1', '::1'])) {
             throw new AuthorizationException('This action is unauthorized.');
         }
 

--- a/src/Http/Middleware/Request.php
+++ b/src/Http/Middleware/Request.php
@@ -23,7 +23,8 @@ class Request
     {
 
         // check if the source is trusted
-        if (! in_array($request->server('REMOTE_ADDR'), [$_SERVER['SERVER_ADDR'], '127.0.0.1', '::1'])) {
+        $requestIp = $request->server('HTTP_CF_CONNECTING_IP') ?? $request->server('REMOTE_ADDR');
+        if (!in_array($requestIp, [$_SERVER['SERVER_ADDR'], '127.0.0.1', '::1'])) {
             throw new AuthorizationException('This action is unauthorized.');
         }
 


### PR DESCRIPTION
This PR fixes artisan commands always returning 403 on sites behind Cloudflare. 

It happened because ```$request->server('REMOTE_ADDR')``` always returning Cloudflare servers IPs, the fix is checking if the Cloudflare header "CF-Connecting-IP" exists and use it as request ip.