### PR TITLE
Support Lumen and set directories to be pre-compiled

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,22 @@ For Lumen:
 ```php
 // bootstrap/app.php
 $app->register(Appstract\Opcache\OpcacheServiceProvider::class);
+$app->configure('opcache');
 
 // config/app.php
 'url' => env('APP_URL'),
+
+// config/opcache.php
+'directories' => [
+    base_path('app'),
+    base_path('bootstrap'),
+    base_path('public'),
+    base_path('routes'),
+    base_path('vendor/appstract'),
+    base_path('vendor/composer'),
+    base_path('vendor/laravel/lumen-framework'),
+    base_path('vendor/illuminate'),
+]
 ```
 Make sure your APP_URL is set correctly in .env.
 If you want to set a different url to call the OPcache routes (for use with a load balancer for example),

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "illuminate/console": ">=5.1",
         "illuminate/support": ">=5.1",
         "illuminate/routing": ">=5.1",
+        "illuminate/filesystem": ">=5.1",
         "appstract/lush-http": "^0.2"
     },
     "require-dev": {

--- a/config/opcache.php
+++ b/config/opcache.php
@@ -1,8 +1,16 @@
 <?php
 
 return [
-
-    //
     'url' => env('OPCACHE_URL', config('app.url')),
-
+    'directories' => [
+        base_path('app'),
+        base_path('bootstrap'),
+        base_path('public'),
+        base_path('resources/lang'),
+        base_path('routes'),
+        base_path('storage/framework/views'),
+        base_path('vendor/appstract'),
+        base_path('vendor/composer'),
+        base_path('vendor/laravel/framework'),
+    ],
 ];

--- a/src/OpcacheClass.php
+++ b/src/OpcacheClass.php
@@ -75,17 +75,7 @@ class OpcacheClass
         }
 
         // Get files in these paths
-        $files = File::allFiles([
-            base_path('app'),
-            base_path('bootstrap'),
-            base_path('public'),
-            base_path('resources/lang'),
-            base_path('routes'),
-            base_path('storage/framework/views'),
-            base_path('vendor/appstract'),
-            base_path('vendor/composer'),
-            base_path('vendor/laravel/framework'),
-        ]);
+        $files = File::allFiles(config('opcache.directories'));
 
         $files = collect($files);
 

--- a/src/OpcacheClass.php
+++ b/src/OpcacheClass.php
@@ -2,7 +2,7 @@
 
 namespace Appstract\Opcache;
 
-use File;
+use Illuminate\Support\Facades\File;
 
 /**
  * Class OpcacheClass.


### PR DESCRIPTION
Hi appstract,

I found some errors when I was requiring this package to Lumen framework (version number: 5.4).

This PR fixes the errors below:

1. Incompatible directories to pre-compiled.
2. Need to require `illuminate/filesystem` package.
3. Add more details of setting with Lumen framework in `README.md`.