### PR TITLE
Missing config causing errors (Lumen)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ You can publish the config file with:
 php artisan vendor:publish --provider="Appstract\Opcache\OpcacheServiceProvider" --tag="config"
 ```
 
-For Lumen:
+### For Lumen:
 ```php
 // bootstrap/app.php
 $app->register(Appstract\Opcache\OpcacheServiceProvider::class);
@@ -52,6 +52,19 @@ $app->configure('opcache');
 Make sure your APP_URL is set correctly in .env.
 If you want to set a different url to call the OPcache routes (for use with a load balancer for example),
 you can set OPCACHE_URL.
+
+You will also need an encryption key set in your `.env` file. Since Lumen does not have a artisan generate command, you can create a tempoary route to generate one for you.
+
+```php
+$router->get('/key', function() {
+    return 'base64:'.base64_encode(random_bytes(32));  
+});
+```
+
+Put the results in your .env file:
+```
+APP_KEY=
+```
 
 ## Usage
 Login to your server/vm and run one of the commands.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $app->configure('opcache');
 'url' => env('APP_URL'),
 
 // config/opcache.php
-'url' => env('OPCACHE_URL', config('app.url')),
+'url' => env('OPCACHE_URL', env('APP_URL')),
 'verify_ssl' => true,
 'headers' => [],
 'directories' => [

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For Lumen:
 $app->register(Appstract\Opcache\OpcacheServiceProvider::class);
 $app->configure('opcache');
 
-// config/app.php
+// config/app.php (Only if you already have a custom app.php file)
 'url' => env('APP_URL'),
 
 // config/opcache.php

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ $app->configure('opcache');
 'url' => env('APP_URL'),
 
 // config/opcache.php
+'url' => env('OPCACHE_URL', config('app.url')),
+'verify_ssl' => true,
+'headers' => [],
 'directories' => [
     base_path('app'),
     base_path('bootstrap'),


### PR DESCRIPTION
Fix for this error in Lumen:

```
[Symfony\Component\Debug\Exception\FatalThrowableError]                                                                                                                                                                
  Argument 1 passed to Appstract\LushHttp\Lush::headers() must be of the type array, null given, called in D:\Spotted Kiwi Dropbox\Assets\Systems Development\MasterServer\vendor\illuminate\support\Facades\Facade.php  
   on line 237 
```