### PR TITLE
Add more paths to config's exclude array

### DIFF
--- a/config/opcache.php
+++ b/config/opcache.php
@@ -15,8 +15,14 @@ return [
         base_path('vendor'),
     ],
     'exclude' => [
+        'test',
+        'Test',
         'tests',
+        'Tests',
+        'stub',
+        'Stub',
         'stubs',
-        'Dumper'
+        'Stubs',
+        'Dumper',
     ]
 ];

--- a/config/opcache.php
+++ b/config/opcache.php
@@ -23,6 +23,6 @@ return [
         'Stub',
         'stubs',
         'Stubs',
-        'Dumper',
+        'Dumper'
     ]
 ];


### PR DESCRIPTION
In a fresh laravel 6.x project running `php artisan opcache:compile --force` throws exception due to existence of a file called `vendor/symfony/var-dumper/Tests/Fixtures/Php74.php` 
adding `Tests` to exclude array fixes the problem.
in addition 
as the exclude function is used at the moment IS case-sensitive and on the other hand there is not any standard convention for third party libraries to name their tests/stubs folder,in a real life project i found all these variants naming in libraries
obviously there is no point to put test folders in opcache so i think trying to exclude as much as test files by default is a good practice 