### PR TITLE
Cyrille37 verify host

### DIFF
--- a/config/opcache.php
+++ b/config/opcache.php
@@ -4,6 +4,7 @@ return [
     'url' => env('OPCACHE_URL', config('app.url')),
     'prefix' => 'opcache-api',
     'verify_ssl' => true,
+    'verify_host' => true,
     'headers' => [],
     'directories' => [
         base_path('app'),

--- a/src/CreatesRequest.php
+++ b/src/CreatesRequest.php
@@ -15,7 +15,7 @@ trait CreatesRequest
     public function sendRequest($url, $parameters = [])
     {
         return Lush::headers(config('opcache.headers'))
-            ->options(['verify_ssl' => config('opcache.verify_ssl')])
+            ->options(['verify_ssl' => config('opcache.verify_ssl'),'verify_host' => config('opcache.verify_host',true)])
             ->get(config('opcache.url').'/'. config('opcache.prefix') . '/'.$url,
             array_merge(['key' => Crypt::encrypt('opcache')], $parameters)
         );


### PR DESCRIPTION
Hello
At dev time it could be fast to use a fake ssl certificate.

Option `verify_ssl` was previously added but it's not enough when self-signed certificate does not match the domain name. So this PR add to the stack the `verify_host` request option (*already present in Lush RequestOptions class*).

Now I can use the fake & dummy `ssl-cert-snakeoil.pem` already present on my linux host ;-)

Cheers.