### PR TITLE
Update .styleci.yml

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,4 @@
 preset: laravel
 
-linting: true
-
 disabled:
   - single_class_element_per_statement


### PR DESCRIPTION
There's no config for linting so we should remove `linting: true` in the .styleci.yml for now.