### PR TITLE
Make URL creation more fault tolerant

### DIFF
--- a/src/CreatesRequest.php
+++ b/src/CreatesRequest.php
@@ -16,7 +16,7 @@ trait CreatesRequest
     {
         return Http::withHeaders(config('opcache.headers'))
             ->withOptions(['verify' => config('opcache.verify')])
-            ->get(config('opcache.url').'/'.config('opcache.prefix').'/'.$url,
+            ->get(rtrim(config('opcache.url'), '/').'/'.trim(config('opcache.prefix'), '/').'/'.ltrim($url, '/'),
                 array_merge(['key' => Crypt::encrypt('opcache')], $parameters)
         );
     }


### PR DESCRIPTION
Hello, 

Firstly, thanks for this awesome package!

I experienced a 404 error on a production environment because APP_URL in my .env had a forward slash `/` at the end of it. As a result, the url was created as "www.example.com//opcache-api", which caused the 404.

I've added trimming to the point where the url is created, which will make this more error proof.

Hopefully you can merge this PR in, if you also think it will benefit users of this package. 

Thanks again!