### PR TITLE
Add support for Guzzle 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "php": "^7.2.5",
         "laravel/framework": ">=7.0",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3.1|^7.0"
     },
     "require-dev": {
         "orchestra/testbench": "^5.0",


### PR DESCRIPTION
[The upgrade from Guzzle 6.x to 7.x has some backwards compatibility breaks](https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#60-to-70), however basic usage is still the same (and generally handled by Laravel's `Http` facade).

This commit ensures that the package will work with Guzzle 6.x or 7.x and [uses the same guzzlehttp/guzzle version constraints as Laravel itself](https://github.com/laravel/framework/blob/7.x/composer.json#L83).

Fixes #112.