### PR TITLE
Report exceptions

### DIFF
--- a/src/OpcacheClass.php
+++ b/src/OpcacheClass.php
@@ -71,7 +71,8 @@ class OpcacheClass
                     }
 
                     $compiled++;
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
+                    report($e);
                 }
             });
 


### PR DESCRIPTION
Hi, if there is any exception thrown during the compilation it's completely ignored and the response from the API is just 500... there is no extra info to figure out what went wrong... so I have added a `report()` to at least get it logged into the logs and give more clues of why there was a 500 error...