### PR TITLE
Add $get_scripts parameter to OpcacheClass::getStatus() method

### DIFF
--- a/src/OpcacheClass.php
+++ b/src/OpcacheClass.php
@@ -32,10 +32,10 @@ class OpcacheClass
     /**
      * Get status info.
      */
-    public function getStatus()
+    public function getStatus($get_scripts=false)
     {
         if (function_exists('opcache_get_status')) {
-            return opcache_get_status(false);
+            return opcache_get_status($get_scripts);
         }
     }
 

--- a/src/OpcacheClass.php
+++ b/src/OpcacheClass.php
@@ -32,7 +32,7 @@ class OpcacheClass
     /**
      * Get status info.
      */
-    public function getStatus($get_scripts=false)
+    public function getStatus($get_scripts = false)
     {
         if (function_exists('opcache_get_status')) {
             return opcache_get_status($get_scripts);


### PR DESCRIPTION
Sometimes I need to know about the scripts loaded via the opcache and see their cache hit times but there was no way to do this with the package methods itself and I think this doesn't break anything, so no harms to have it.
Thanks