### PR TITLE
Allow to cache the rest of files even when one of them is not cacheable

### DIFF
--- a/src/OpcacheClass.php
+++ b/src/OpcacheClass.php
@@ -53,6 +53,7 @@ class OpcacheClass
 
         if (function_exists('opcache_compile_file')) {
             $compiled = 0;
+            $uncompiled = [];
 
             // Get files in these paths
             $files = collect(Finder::create()->in(config('opcache.directories'))
@@ -71,13 +72,15 @@ class OpcacheClass
                     }
 
                     $compiled++;
-                } catch (\Exception $e) {
+                } catch (\Throwable $e) {
+                    $uncompiled[] = $file.':'.$e->getMessage();
                 }
             });
 
             return [
                 'total_files_count' => $files->count(),
                 'compiled_count' => $compiled,
+                'uncompiled_files' => $uncompiled,
             ];
         }
     }


### PR DESCRIPTION
Some files may have sintax errors, since the vendor directory may not be under your control, it should better to catch Throwable instead of Exception, to allow to cache the rest of the files.

I also added the uncompiled list of files with errors to the output, to show the list of files that weren't cached.