### PR TITLE
Exclude "examples" directory

### DIFF
--- a/config/opcache.php
+++ b/config/opcache.php
@@ -15,6 +15,7 @@ return [
         base_path('vendor'),
     ],
     'exclude' => [
+        'examples',
         'test',
         'Test',
         'tests',


### PR DESCRIPTION
"examples" is a common directory name for files that demonstrate how to use a library, but not actually part of the code that is exposed to the autoloader. Example files may declare duplicated objects (classes, functions) which is an issue if they are all loaded in the same process.