### PR TITLE
Make fetching files more memory efficient

### DIFF
--- a/src/OpcacheClass.php
+++ b/src/OpcacheClass.php
@@ -42,7 +42,7 @@ class OpcacheClass
     /**
      * Pre-compile php scripts.
      *
-     * @param bool $force
+     * @param  bool $force
      * @return array
      */
     public function compile($force = false)
@@ -68,7 +68,7 @@ class OpcacheClass
                 foreach ($finder as $file) {
                     yield $file;
                 }
-            });            
+            });
 
             // optimized files
             $files->each(function ($file) use (&$compiled) {

--- a/src/OpcacheClass.php
+++ b/src/OpcacheClass.php
@@ -55,13 +55,20 @@ class OpcacheClass
             $compiled = 0;
 
             // Get files in these paths
-            $files = collect(Finder::create()->in(config('opcache.directories'))
-                ->name('*.php')
-                ->ignoreUnreadableDirs()
-                ->notContains('#!/usr/bin/env php')
-                ->exclude(config('opcache.exclude'))
-                ->files()
-                ->followLinks());
+            $files = LazyCollection::make(function () {
+                $finder = Finder::create()
+                    ->in(config('opcache.directories'))
+                    ->name('*.php')
+                    ->ignoreUnreadableDirs()
+                    ->notContains('#!/usr/bin/env php')
+                    ->exclude(config('opcache.exclude'))
+                    ->files()
+                    ->followLinks();
+
+                foreach ($finder as $file) {
+                    yield $file;
+                }
+            });            
 
             // optimized files
             $files->each(function ($file) use (&$compiled) {

--- a/src/OpcacheClass.php
+++ b/src/OpcacheClass.php
@@ -42,7 +42,7 @@ class OpcacheClass
     /**
      * Pre-compile php scripts.
      *
-     * @param  bool $force
+     * @param  bool  $force
      * @return array
      */
     public function compile($force = false)


### PR DESCRIPTION
Make the code more memory efficient when fetching files to compile. The previous implementation easily ran into trouble when dealing with larger codebases, this introduces LazyCollections instead as a way to handle large datasets in a memory efficient way.